### PR TITLE
Add checking singleton exists or not and skipping install

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -208,6 +208,9 @@ function wait_for_operator() {
     local operator_name=$2
     local condition="${OC} -n ${namespace} get csv --no-headers --ignore-not-found | egrep 'Succeeded' | grep ^${operator_name}"
     local retries=50
+    if [ "x$3" != "x" ]; then
+        retries=$3
+    fi
     local sleep_time=10
     local total_time_mins=$(( sleep_time * retries / 60))
     local wait_message="Waiting for operator ${operator_name} in namespace ${namespace} to be made available"

--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -208,9 +208,6 @@ function wait_for_operator() {
     local operator_name=$2
     local condition="${OC} -n ${namespace} get csv --no-headers --ignore-not-found | egrep 'Succeeded' | grep ^${operator_name}"
     local retries=50
-    if [ "x$3" != "x" ]; then
-        retries=$3
-    fi
     local sleep_time=10
     local total_time_mins=$(( sleep_time * retries / 60))
     local wait_message="Waiting for operator ${operator_name} in namespace ${namespace} to be made available"

--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -18,7 +18,8 @@ INSTALL_MODE="Automatic"
 CERT_MANAGER_SOURCE="ibm-cert-manager-operator-catalog"
 LICENSING_SOURCE="ibm-licensing-catalog"
 
-SKIP_INSTALL=false
+SKIP_INSTALL=0
+CHECK_LICENSING_ONLY=0
 
 # ---------- Command variables ----------
 
@@ -66,11 +67,11 @@ function parse_arguments() {
             LICENSING_SOURCE=$1
             ;;
         --check-cert-manager)
-            SKIP_INSTALL=true
+            SKIP_INSTALL=1
             ;;
         --check-licensing)
             CHECK_LICENSING_ONLY=1
-            SKIP_INSTALL=true           
+            SKIP_INSTALL=1           
             ;;
         -h | --help)
             print_usage
@@ -126,7 +127,7 @@ function install_cert_manager() {
         SOURCE_NS="ibm-cert-manager"
     fi
 
-    if [ $SKIP_INSTALL = true ]; then
+    if [ $SKIP_INSTALL -eq 1 ]; then
         wait_for_operator "ibm-cert-manager" "ibm-cert-manager-operator" 6 # only wait 1 min by retrying 6 times
         return
     fi
@@ -154,7 +155,7 @@ function install_licensing() {
         SOURCE_NS="ibm-licensing"
     fi
 
-    if [ $SKIP_INSTALL = true ]; then
+    if [ $SKIP_INSTALL -eq 1 ]; then
         wait_for_operator "ibm-licensing" "ibm-licensing-operator" 6 # only wait 1 min by retrying 6 times
         return
     fi

--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -115,21 +115,22 @@ function install_cert_manager() {
     if [ $? -eq 0 ]; then
         warning "There is a cert-manager Subscription already\n"
         return 0
+    elif [ $SKIP_INSTALL -eq 1 ]; then
+        warning "There is no cert-manager Subscription installed\n"
+        exit 1
     fi
 
     pods_exist=$(${OC} get pods -A | grep -w cert-manager-webhook)
     if [ $? -eq 0 ]; then
         warning "There is a cert-manager-webhook pod Running, so most likely another cert-manager is already installed\n"
         return 0
+    elif [ $SKIP_INSTALL -eq 1 ]; then
+        warning "There is no cert-manager-webhook pod running\n"
+        exit 1
     fi
 
     if [ $ENABLE_PRIVATE_CATALOG -eq 1 ]; then
         SOURCE_NS="ibm-cert-manager"
-    fi
-
-    if [ $SKIP_INSTALL -eq 1 ]; then
-        wait_for_operator "ibm-cert-manager" "ibm-cert-manager-operator" 6 # only wait 1 min by retrying 6 times
-        return
     fi
 
     create_namespace ibm-cert-manager
@@ -149,15 +150,13 @@ function install_licensing() {
     if [ $? -eq 0 ]; then
         warning "There is an ibm-licensing-operator Subscription already\n"
         return 0
+    elif [ $SKIP_INSTALL -eq 1 ]; then
+        warning "There is no ibm-licensing-operator Subscription installed\n"
+        exit 1
     fi
 
     if [ $ENABLE_PRIVATE_CATALOG -eq 1 ]; then
         SOURCE_NS="ibm-licensing"
-    fi
-
-    if [ $SKIP_INSTALL -eq 1 ]; then
-        wait_for_operator "ibm-licensing" "ibm-licensing-operator" 6 # only wait 1 min by retrying 6 times
-        return
     fi
 
     create_namespace ibm-licensing


### PR DESCRIPTION
1. Introduced two flags `--check-cert-manager` and `--check-licensing` to implement singleton checking and skipping installation.
2. The two flags are not included in the usage so that they are not exposed to other users.
3. Olm-utils side could directly call `setup_singleton.sh --check-cert-manager` to check whether cert manager is installed or not. 

Tests:
1. check cert manager only
```
# ./setup_singleton.sh --check-cert-manager
[✔] oc command available
[✔] oc command logged in as kube:admin
# Installing cert-manager

[✗] There is no cert-manager Subscription installed

[root@api.mcoc48.cp.fyre.ibm.com cp3pt0-deployment]# echo $?
1
```

2. check licensing only
```
# ./setup_singleton.sh --check-licensing
[✔] oc command available
[✔] oc command logged in as kube:admin
# Installing licensing

[✗] There is no ibm-licensing-operator Subscription installed

[root@api.mcoc48.cp.fyre.ibm.com cp3pt0-deployment]# echo $?
1
```

3. install
```
# ./setup_singleton.sh  --enable-private-catalog  --enable-licensing
[✔] oc command available
[✔] oc command logged in as kube:admin
# Installing cert-manager

# Creating namespace ibm-cert-manager

[INFO] Namespace ibm-cert-manager already exists. Skip creating
[INFO] Checking existing OperatorGroup in ibm-cert-manager:

[INFO] OperatorGroup already exists in ibm-cert-manager. Skip creating

[INFO] Creating following Subscription:

apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: ibm-cert-manager-operator
  namespace: ibm-cert-manager
spec:
  channel: v4.0
  installPlanApproval: Automatic
  name: ibm-cert-manager-operator
  source: ibm-cert-manager-operator-catalog
  sourceNamespace: ibm-cert-manager
subscription.operators.coreos.com/ibm-cert-manager-operator created
[INFO] Waiting for operator ibm-cert-manager-operator in namespace ibm-cert-manager to be made available
[INFO] RETRYING: Waiting for operator ibm-cert-manager-operator in namespace ibm-cert-manager to be made available (50 left)
[✔] Operator ibm-cert-manager-operator in namespace ibm-cert-manager is available
# Installing licensing

# Creating namespace ibm-licensing

[INFO] Namespace ibm-licensing already exists. Skip creating
[INFO] Checking existing OperatorGroup in ibm-licensing:

[INFO] OperatorGroup already exists in ibm-licensing. Skip creating

[INFO] Creating following Subscription:

apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: ibm-licensing-operator-app
  namespace: ibm-licensing
spec:
  channel: v4.0
  installPlanApproval: Automatic
  name: ibm-licensing-operator-app
  source: ibm-licensing-catalog
  sourceNamespace: ibm-licensing
subscription.operators.coreos.com/ibm-licensing-operator-app created
[INFO] Waiting for operator ibm-licensing-operator in namespace ibm-licensing to be made available
[INFO] RETRYING: Waiting for operator ibm-licensing-operator in namespace ibm-licensing to be made available (50 left)
[INFO] RETRYING: Waiting for operator ibm-licensing-operator in namespace ibm-licensing to be made available (49 left)
[✔] Operator ibm-licensing-operator in namespace ibm-licensing is available
```